### PR TITLE
fixed issue 85 by blocking the rotation in reminder activity

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
@@ -3,6 +3,7 @@ package org.fossify.clock.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
@@ -53,6 +54,7 @@ class ReminderActivity : SimpleActivity() {
         showOverLockscreen()
         updateTextColors(binding.root)
         updateStatusbarColor(getProperBackgroundColor())
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
         val id = intent.getIntExtra(ALARM_ID, -1)
         isAlarmReminder = id != -1


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Bug fix by blocking the rotation of Reminder Activity to prevent snooze issues in landscape mode

- I found this solution because it does not significantly modify the existing code. Moreover, it can be more user-friendly, as the alarm won’t unexpectedly rotate while the user is trying to disable it.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #85 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
