### PR TITLE
Fix issue85

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
@@ -3,14 +3,12 @@ package org.fossify.clock.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.*
 import android.provider.AlarmClock
-import android.util.Log
 import android.view.MotionEvent
 import android.view.WindowManager
 import android.view.animation.AnimationUtils
@@ -231,8 +229,7 @@ class ReminderActivity : SimpleActivity() {
         super.onConfigurationChanged(newConfig)
         setupAlarmButtons()
     }
-
-
+    
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent?.action == AlarmClock.ACTION_SNOOZE_ALARM) {

--- a/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
@@ -229,7 +229,7 @@ class ReminderActivity : SimpleActivity() {
         super.onConfigurationChanged(newConfig)
         setupAlarmButtons()
     }
-    
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent?.action == AlarmClock.ACTION_SNOOZE_ALARM) {

--- a/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
@@ -3,6 +3,7 @@ package org.fossify.clock.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
@@ -53,6 +54,7 @@ class ReminderActivity : SimpleActivity() {
         showOverLockscreen()
         updateTextColors(binding.root)
         updateStatusbarColor(getProperBackgroundColor())
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
         val id = intent.getIntExtra(ALARM_ID, -1)
         isAlarmReminder = id != -1

--- a/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
+++ b/app/src/main/kotlin/org/fossify/clock/activities/ReminderActivity.kt
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.*
 import android.provider.AlarmClock
+import android.util.Log
 import android.view.MotionEvent
 import android.view.WindowManager
 import android.view.animation.AnimationUtils
@@ -54,7 +56,6 @@ class ReminderActivity : SimpleActivity() {
         showOverLockscreen()
         updateTextColors(binding.root)
         updateStatusbarColor(getProperBackgroundColor())
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
         val id = intent.getIntExtra(ALARM_ID, -1)
         isAlarmReminder = id != -1
@@ -225,6 +226,12 @@ class ReminderActivity : SimpleActivity() {
             audioManager?.setStreamVolume(AudioManager.STREAM_ALARM, this, 0)
         }
     }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        setupAlarmButtons()
+    }
+
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Bug fix using the onConfigurationChanged() method to recall setupAlarmButtons() when the screen is rotated.
- The bug was caused by the binding.reminderDraggable.x value not being updated after rotation.
- Recalling setupAlarmButtons() allows the coordinates to be recalculated and fixes the issue.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #85 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- Needs to import android.content.res.Configuration for the onConfigurationChanged() method


#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
