### PR TITLE
Fixed widget not respecting the tab setting (#125)

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/helpers/MyAnalogueTimeWidgetProvider.kt
+++ b/app/src/main/kotlin/org/fossify/clock/helpers/MyAnalogueTimeWidgetProvider.kt
@@ -41,7 +41,6 @@ class MyAnalogueTimeWidgetProvider : AppWidgetProvider() {
 
     private fun setupAppOpenIntent(context: Context, views: RemoteViews) {
         (context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)).apply {
-            putExtra(OPEN_TAB, TAB_CLOCK)
             val pendingIntent = PendingIntent.getActivity(context, OPEN_APP_INTENT_ID, this, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             views.setOnClickPendingIntent(R.id.widget_date_time_holder, pendingIntent)
         }

--- a/app/src/main/kotlin/org/fossify/clock/helpers/MyDigitalTimeWidgetProvider.kt
+++ b/app/src/main/kotlin/org/fossify/clock/helpers/MyDigitalTimeWidgetProvider.kt
@@ -70,7 +70,6 @@ class MyDigitalTimeWidgetProvider : AppWidgetProvider() {
 
     private fun setupAppOpenIntent(context: Context, views: RemoteViews) {
         (context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)).apply {
-            putExtra(OPEN_TAB, TAB_CLOCK)
             val pendingIntent = PendingIntent.getActivity(context, OPEN_APP_INTENT_ID, this, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             views.setOnClickPendingIntent(R.id.widget_date_time_holder, pendingIntent)
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Fixed analog and digital clock widgets to respect the default tab setting.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

- Before:

https://github.com/user-attachments/assets/ee9fc744-a7c3-4f8a-b105-47ef073191c8

- After:

https://github.com/user-attachments/assets/ef4e5654-5292-4454-93b6-81da67ae4f9a

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #125 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
