### PR TITLE
Fix misleading toast when disabling one-shot alarms

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/adapters/AlarmsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/clock/adapters/AlarmsAdapter.kt
@@ -10,7 +10,12 @@ import androidx.recyclerview.widget.RecyclerView
 import org.fossify.clock.R
 import org.fossify.clock.activities.SimpleActivity
 import org.fossify.clock.databinding.ItemAlarmBinding
-import org.fossify.clock.extensions.*
+import org.fossify.clock.extensions.config
+import org.fossify.clock.extensions.dbHelper
+import org.fossify.clock.extensions.getAlarmSelectedDaysString
+import org.fossify.clock.extensions.getFormattedTime
+import org.fossify.clock.extensions.scheduleNextAlarm
+import org.fossify.clock.extensions.swap
 import org.fossify.clock.helpers.TODAY_BIT
 import org.fossify.clock.helpers.TOMORROW_BIT
 import org.fossify.clock.helpers.getCurrentDayMinutes
@@ -28,8 +33,11 @@ import org.fossify.commons.interfaces.StartReorderDragListener
 import org.fossify.commons.views.MyRecyclerView
 
 class AlarmsAdapter(
-    activity: SimpleActivity, var alarms: ArrayList<Alarm>, val toggleAlarmInterface: ToggleAlarmInterface,
-    recyclerView: MyRecyclerView, itemClick: (Any) -> Unit,
+    activity: SimpleActivity,
+    var alarms: ArrayList<Alarm>,
+    val toggleAlarmInterface: ToggleAlarmInterface,
+    recyclerView: MyRecyclerView,
+    itemClick: (Any) -> Unit,
 ) : MyRecyclerViewAdapter(activity, recyclerView, itemClick), ItemTouchHelperContract {
 
     private var startReorderDragListener: StartReorderDragListener
@@ -115,7 +123,9 @@ class AlarmsAdapter(
         activity.dbHelper.deleteAlarms(alarmsToRemove)
     }
 
-    private fun getSelectedItems() = alarms.filter { selectedKeys.contains(it.id) } as ArrayList<Alarm>
+    private fun getSelectedItems(): ArrayList<Alarm> {
+        return alarms.filter { selectedKeys.contains(it.id) } as ArrayList<Alarm>
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun setupView(view: View, alarm: Alarm, holder: ViewHolder) {
@@ -143,35 +153,46 @@ class AlarmsAdapter(
             alarmSwitch.isChecked = alarm.isEnabled
             alarmSwitch.setColors(textColor, properPrimaryColor, backgroundColor)
             alarmSwitch.setOnClickListener {
-                if (alarm.days > 0) {
-                    if (activity.config.wasAlarmWarningShown) {
-                        toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
-                    } else {
-                        ConfirmationDialog(
-                            activity,
-                            messageId = org.fossify.commons.R.string.alarm_warning,
-                            positive = org.fossify.commons.R.string.ok,
-                            negative = 0
-                        ) {
-                            activity.config.wasAlarmWarningShown = true
+                when {
+                    alarm.days > 0 -> {
+                        if (activity.config.wasAlarmWarningShown) {
                             toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
+                        } else {
+                            ConfirmationDialog(
+                                activity = activity,
+                                messageId = org.fossify.commons.R.string.alarm_warning,
+                                positive = org.fossify.commons.R.string.ok,
+                                negative = 0
+                            ) {
+                                activity.config.wasAlarmWarningShown = true
+                                toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
+                            }
                         }
                     }
-                } else if (alarm.days == TODAY_BIT) {
-                    if (alarm.timeInMinutes <= getCurrentDayMinutes()) {
-                        alarm.days = TOMORROW_BIT
-                        alarmDays.text = resources.getString(org.fossify.commons.R.string.tomorrow)
+
+                    alarm.days == TODAY_BIT -> {
+                        if (alarm.timeInMinutes <= getCurrentDayMinutes()) {
+                            alarm.days = TOMORROW_BIT
+                            alarmDays.text =
+                                resources.getString(org.fossify.commons.R.string.tomorrow)
+                        }
+                        activity.dbHelper.updateAlarm(alarm)
+                        root.context.scheduleNextAlarm(alarm, true)
+                        toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
                     }
-                    activity.dbHelper.updateAlarm(alarm)
-                    root.context.scheduleNextAlarm(alarm, true)
-                    toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
-                } else if (alarm.days == TOMORROW_BIT) {
-                    toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
-                } else if (alarmSwitch.isChecked) {
-                    activity.toast(R.string.no_days_selected)
-                    alarmSwitch.isChecked = false
-                } else {
-                    toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
+
+                    alarm.days == TOMORROW_BIT -> {
+                        toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
+                    }
+
+                    alarmSwitch.isChecked -> {
+                        activity.toast(R.string.no_days_selected)
+                        alarmSwitch.isChecked = false
+                    }
+
+                    else -> {
+                        toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/org/fossify/clock/adapters/AlarmsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/clock/adapters/AlarmsAdapter.kt
@@ -14,7 +14,6 @@ import org.fossify.clock.extensions.config
 import org.fossify.clock.extensions.dbHelper
 import org.fossify.clock.extensions.getAlarmSelectedDaysString
 import org.fossify.clock.extensions.getFormattedTime
-import org.fossify.clock.extensions.scheduleNextAlarm
 import org.fossify.clock.extensions.swap
 import org.fossify.clock.helpers.TODAY_BIT
 import org.fossify.clock.helpers.TOMORROW_BIT
@@ -177,7 +176,6 @@ class AlarmsAdapter(
                                 resources.getString(org.fossify.commons.R.string.tomorrow)
                         }
                         activity.dbHelper.updateAlarm(alarm)
-                        root.context.scheduleNextAlarm(alarm, true)
                         toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
                     }
 
@@ -185,6 +183,7 @@ class AlarmsAdapter(
                         toggleAlarmInterface.alarmToggled(alarm.id, alarmSwitch.isChecked)
                     }
 
+                    // Unreachable zombie branch. Days are always set to a non-zero value.
                     alarmSwitch.isChecked -> {
                         activity.toast(R.string.no_days_selected)
                         alarmSwitch.isChecked = false


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed unnecessary call to `Context.scheduleNextAlarm(alarm, true)` which led to the toast message.
- Minor code style change

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #26

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
