### PR TITLE
Add `Alarm timed out` string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="not_scheduled">Not scheduled</string>
     <string name="missed_alarm">Missed alarm</string>
     <string name="replaced_by_another_alarm">Replaced by another alarm</string>
+    <string name="alarm_timed_out">Alarm timed out</string>
 
     <!-- Timer -->
     <string name="timers_notification_msg">Timers are running</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

Added `Alarm timed out` string. It'll be displayed as a reason in missed alarm notifications when alarms are dismissed automatically.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
