### PR TITLE
fix(audio): remove `AUDIBILITY_ENFORCED` flag from `AudioAttributes`

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
+++ b/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
@@ -114,7 +114,6 @@ class AlarmService : Service() {
                 val audioAttributes = AudioAttributes.Builder()
                     .setUsage(AudioAttributes.USAGE_ALARM)
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
                     .build()
 
                 mediaPlayer = MediaPlayer().apply {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
The `AUDIBILITY_ENFORCED` flag was causing full-volume alarms on Samsung devices even when alarm volume was set low. It was copy-pasted from the original code that used notification sounds for alarms, but according to the docs, this flag should only be used for sounds subject to regulatory behaviors, e.g., camera shutter sound.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #158

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Clock/blob/master/CONTRIBUTING.md).
