### PR TITLE
fix: rework how time is calculated in stopwatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated translations
+
+### Fixed
+
+- Fixed inaccuracy in stopwatch over long durations ([#207])
+
 ## [1.2.1] - 2025-05-08
 
 ### Changed
@@ -75,3 +83,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/FossifyOrg/Clock/releases/tag/1.0.0
 
 [#158]: https://github.com/FossifyOrg/Clock/issues/158
+[#207]: https://github.com/FossifyOrg/Clock/issues/207

--- a/app/src/main/kotlin/org/fossify/clock/adapters/StopwatchAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/clock/adapters/StopwatchAdapter.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import org.fossify.clock.activities.SimpleActivity
 import org.fossify.clock.databinding.ItemLapBinding
 import org.fossify.clock.extensions.formatStopwatchTime
@@ -15,11 +14,12 @@ import org.fossify.clock.models.Lap
 import org.fossify.commons.adapters.MyRecyclerViewAdapter
 import org.fossify.commons.views.MyRecyclerView
 
-class StopwatchAdapter(activity: SimpleActivity, var laps: ArrayList<Lap>, recyclerView: MyRecyclerView, itemClick: (Any) -> Unit) :
-    MyRecyclerViewAdapter(activity, recyclerView, itemClick) {
-    private var lastLapTimeView: TextView? = null
-    private var lastTotalTimeView: TextView? = null
-    private var lastLapId = 0
+class StopwatchAdapter(
+    activity: SimpleActivity,
+    var laps: ArrayList<Lap>,
+    recyclerView: MyRecyclerView,
+    itemClick: (Any) -> Unit,
+) : MyRecyclerViewAdapter(activity, recyclerView, itemClick) {
 
     override fun getActionMenuId() = 0
 
@@ -43,7 +43,7 @@ class StopwatchAdapter(activity: SimpleActivity, var laps: ArrayList<Lap>, recyc
         return createViewHolder(ItemLapBinding.inflate(layoutInflater, parent, false).root)
     }
 
-    override fun onBindViewHolder(holder: MyRecyclerViewAdapter.ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val lap = laps[position]
         holder.bindView(lap, false, false) { itemView, layoutPosition ->
             setupView(itemView, lap)
@@ -55,16 +55,9 @@ class StopwatchAdapter(activity: SimpleActivity, var laps: ArrayList<Lap>, recyc
 
     @SuppressLint("NotifyDataSetChanged")
     fun updateItems(newItems: ArrayList<Lap>) {
-        lastLapId = 0
-        laps = newItems.clone() as ArrayList<Lap>
-        laps.sort()
+        laps = newItems
         notifyDataSetChanged()
         finishActMode()
-    }
-
-    fun updateLastField(lapTime: Long, totalTime: Long) {
-        lastLapTimeView?.text = lapTime.formatStopwatchTime(false)
-        lastTotalTimeView?.text = totalTime.formatStopwatchTime(false)
     }
 
     private fun setupView(view: View, lap: Lap) {
@@ -85,12 +78,6 @@ class StopwatchAdapter(activity: SimpleActivity, var laps: ArrayList<Lap>, recyc
             lapTotalTime.setTextColor(textColor)
             lapTotalTime.setOnClickListener {
                 itemClick(SORT_BY_TOTAL_TIME)
-            }
-
-            if (lap.id > lastLapId) {
-                lastLapTimeView = lapLapTime
-                lastTotalTimeView = lapTotalTime
-                lastLapId = lap.id
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/clock/helpers/Stopwatch.kt
+++ b/app/src/main/kotlin/org/fossify/clock/helpers/Stopwatch.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.fossify.clock.models.Lap
 import java.util.concurrent.CopyOnWriteArraySet
@@ -114,7 +115,7 @@ object Stopwatch {
     private fun startUpdateJob() {
         updateJob?.cancel()
         updateJob = scope.launch {
-            while (state == State.RUNNING) {
+            while (isActive && state == State.RUNNING) {
                 val now = SystemClock.elapsedRealtime()
                 notifyListeners(
                     totalTime = accumulatedTime + (now - startTime),

--- a/app/src/main/kotlin/org/fossify/clock/helpers/Stopwatch.kt
+++ b/app/src/main/kotlin/org/fossify/clock/helpers/Stopwatch.kt
@@ -1,76 +1,79 @@
 package org.fossify.clock.helpers
 
 import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.fossify.clock.models.Lap
-import java.util.Timer
-import java.util.TimerTask
 import java.util.concurrent.CopyOnWriteArraySet
 
-private const val UPDATE_INTERVAL = 10L
+private const val UPDATE_INTERVAL_MS = 20L
 
 object Stopwatch {
-
-    private var updateTimer = Timer()
-    private var uptimeAtStart = 0L
-    private var totalTicks = 0
-    private var currentTicks = 0    // ticks that reset at pause
-    private var lapTicks = 0
+    private var startTime = 0L
+    private var accumulatedTime = 0L
+    private var lapStartTime = 0L
+    private var accumulatedLapTime = 0L
     private var currentLap = 1
+
+    private val updateListeners = CopyOnWriteArraySet<UpdateListener>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var updateJob: Job? = null
+
     val laps = ArrayList<Lap>()
     var state = State.STOPPED
         private set(value) {
             field = value
-            for (listener in updateListeners) {
-                listener.onStateChanged(value)
+            updateListeners.forEach {
+                it.onStateChanged(value)
             }
         }
-    private var updateListeners = CopyOnWriteArraySet<UpdateListener>()
 
     fun reset() {
-        updateTimer.cancel()
+        cancelUpdateJob()
         state = State.STOPPED
-        currentTicks = 0
-        totalTicks = 0
+        accumulatedTime = 0L
+        lapStartTime = 0L
+        accumulatedLapTime = 0L
         currentLap = 1
-        lapTicks = 0
         laps.clear()
+        notifyListeners(totalTime = 0, lapTime = 0, useLongerMSFormat = false)
     }
 
-    fun toggle(setUptimeAtStart: Boolean) {
+    fun toggle() {
+        val now = SystemClock.elapsedRealtime()
         if (state != State.RUNNING) {
             state = State.RUNNING
-            updateTimer = buildUpdateTimer()
-            if (setUptimeAtStart) {
-                uptimeAtStart = SystemClock.uptimeMillis()
-            }
+            startTime = now
+            lapStartTime = now
+            startUpdateJob()
         } else {
             state = State.PAUSED
-            val prevSessionsMS = (totalTicks - currentTicks) * UPDATE_INTERVAL
-            val totalDuration = SystemClock.uptimeMillis() - uptimeAtStart + prevSessionsMS
-            updateTimer.cancel()
-            currentTicks = 0
-            totalTicks--
-            for (listener in updateListeners) {
-                listener.onUpdate(totalDuration, -1, true)
-            }
+            cancelUpdateJob()
+            accumulatedTime += now - startTime
+            accumulatedLapTime += now - lapStartTime
+            notifyListeners(
+                totalTime = accumulatedTime,
+                lapTime = accumulatedLapTime,
+                useLongerMSFormat = true
+            )
         }
     }
 
     fun lap() {
-        if (laps.isEmpty()) {
-            val lap = Lap(currentLap++, lapTicks * UPDATE_INTERVAL, totalTicks * UPDATE_INTERVAL)
-            laps.add(0, lap)
-            lapTicks = 0
-        } else {
-            laps.first().apply {
-                lapTime = lapTicks * UPDATE_INTERVAL
-                totalTime = totalTicks * UPDATE_INTERVAL
-            }
-        }
+        if (state != State.RUNNING) return
 
-        val lap = Lap(currentLap++, lapTicks * UPDATE_INTERVAL, totalTicks * UPDATE_INTERVAL)
+        val now = SystemClock.elapsedRealtime()
+        val lapDuration = accumulatedLapTime + (now - lapStartTime)
+        val totalDuration = accumulatedTime + (now - startTime)
+
+        val lap = Lap(id = currentLap++, lapTime = lapDuration, totalTime = totalDuration)
         laps.add(0, lap)
-        lapTicks = 0
+        lapStartTime = now
+        accumulatedLapTime = 0L
     }
 
     /**
@@ -81,10 +84,21 @@ object Stopwatch {
      */
     fun addUpdateListener(updateListener: UpdateListener) {
         updateListeners.add(updateListener)
+        val totalDuration: Long
+        val lapDuration: Long
+        if (state == State.RUNNING) {
+            val now = SystemClock.elapsedRealtime()
+            totalDuration = accumulatedTime + (now - startTime)
+            lapDuration = accumulatedLapTime + (now - lapStartTime)
+        } else {
+            totalDuration = accumulatedTime
+            lapDuration = accumulatedLapTime
+        }
+
         updateListener.onUpdate(
-            totalTicks * UPDATE_INTERVAL,
-            lapTicks * UPDATE_INTERVAL,
-            state != State.STOPPED
+            totalTime = totalDuration,
+            lapTime = lapDuration,
+            useLongerMSFormat = state != State.STOPPED
         )
         updateListener.onStateChanged(state)
     }
@@ -97,26 +111,33 @@ object Stopwatch {
         updateListeners.remove(updateListener)
     }
 
-    private fun buildUpdateTimer(): Timer {
-        return Timer().apply {
-            scheduleAtFixedRate(object : TimerTask() {
-                override fun run() {
-                    if (state == State.RUNNING) {
-                        if (totalTicks % 10 == 0) {
-                            for (listener in updateListeners) {
-                                listener.onUpdate(
-                                    totalTicks * UPDATE_INTERVAL,
-                                    lapTicks * UPDATE_INTERVAL,
-                                    false
-                                )
-                            }
-                        }
-                        totalTicks++
-                        currentTicks++
-                        lapTicks++
-                    }
-                }
-            }, 0, UPDATE_INTERVAL)
+    private fun startUpdateJob() {
+        updateJob?.cancel()
+        updateJob = scope.launch {
+            while (state == State.RUNNING) {
+                val now = SystemClock.elapsedRealtime()
+                notifyListeners(
+                    totalTime = accumulatedTime + (now - startTime),
+                    lapTime = accumulatedLapTime + (now - lapStartTime),
+                    useLongerMSFormat = false
+                )
+                delay(UPDATE_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun cancelUpdateJob() {
+        updateJob?.cancel()
+        updateJob = null
+    }
+
+    private fun notifyListeners(totalTime: Long, lapTime: Long, useLongerMSFormat: Boolean) {
+        updateListeners.forEach {
+            it.onUpdate(
+                totalTime = totalTime,
+                lapTime = lapTime,
+                useLongerMSFormat = useLongerMSFormat
+            )
         }
     }
 


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Removed the timer-based tick logic. Time is now calculated using `SystemClock.elapsedRealtime()`.
- Simplified live lap management

#### Fixes the following issue(s)
- Fixes #207 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).