### PR TITLE
fix: scale down AM/PM in clock fragment

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/fragments/ClockFragment.kt
+++ b/app/src/main/kotlin/org/fossify/clock/fragments/ClockFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import org.fossify.clock.R
 import org.fossify.clock.activities.SimpleActivity
 import org.fossify.clock.adapters.TimeZonesAdapter
 import org.fossify.clock.databinding.FragmentClockBinding
@@ -93,13 +92,6 @@ class ClockFragment : Fragment() {
         val hours = (passedSeconds / 3600) % 24
         val minutes = (passedSeconds / 60) % 60
         val seconds = passedSeconds % 60
-
-        val safeContext = context ?: return
-        if (!safeContext.config.use24HourFormat) {
-            binding.clockTime.textSize =
-                resources.getDimension(R.dimen.clock_text_size_smaller) / resources.displayMetrics.density
-        }
-
         if (seconds == 0) {
             if (hours == 0 && minutes == 0) {
                 updateDate()

--- a/app/src/main/kotlin/org/fossify/clock/views/MyTextClock.kt
+++ b/app/src/main/kotlin/org/fossify/clock/views/MyTextClock.kt
@@ -1,0 +1,73 @@
+package org.fossify.clock.views
+
+import android.content.Context
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.RelativeSizeSpan
+import android.util.AttributeSet
+import android.widget.TextClock
+import androidx.annotation.AttrRes
+import org.fossify.clock.extensions.config
+import java.text.DateFormatSymbols
+
+private const val AM_PM_SCALE = 0.4f
+
+class MyTextClock @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = android.R.attr.textViewStyle,
+) : TextClock(context, attrs, defStyleAttr) {
+
+    private val amPmStrings by lazy {
+        DateFormatSymbols.getInstance(
+            resources.configuration.locales[0]
+        ).amPmStrings
+    }
+
+    private var reenter = false
+
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        if (reenter) {
+            super.setText(text, type)
+            return
+        }
+
+        if (context.config.use24HourFormat || text.isNullOrEmpty()) {
+            super.setText(text, type)
+            return
+        }
+
+        val full = text.toString()
+        var index = -1
+        var amPmString: String? = null
+        for (s in amPmStrings) {
+            if (s.isNotEmpty()) {
+                val i = full.indexOf(s, ignoreCase = true)
+                if (i != -1) {
+                    index = i
+                    amPmString = s
+                    break
+                }
+            }
+        }
+
+        if (index != -1 && amPmString != null) {
+            val spannable = SpannableString(text)
+            spannable.setSpan(
+                RelativeSizeSpan(AM_PM_SCALE),
+                index - 1, // including the space before AM/PM
+                index + amPmString.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            reenter = true
+
+            try {
+                super.setText(spannable, type ?: BufferType.SPANNABLE)
+            } finally {
+                reenter = false
+            }
+        } else {
+            super.setText(text, type)
+        }
+    }
+}

--- a/app/src/main/res/layout-land/fragment_stopwatch.xml
+++ b/app/src/main/res/layout-land/fragment_stopwatch.xml
@@ -18,6 +18,7 @@
         android:background="?attr/selectableItemBackground"
         android:fontFeatureSettings="tnum"
         android:gravity="center_horizontal"
+        android:layout_marginBottom="@dimen/medium_margin"
         android:includeFontPadding="false"
         android:maxLines="1"
         android:padding="@dimen/small_margin"

--- a/app/src/main/res/layout/fragment_clock.xml
+++ b/app/src/main/res/layout/fragment_clock.xml
@@ -11,13 +11,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextClock
+        <org.fossify.clock.views.MyTextClock
             android:id="@+id/clock_time"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/big_margin"
             android:layout_marginTop="@dimen/activity_margin"
+            android:layout_marginBottom="@dimen/small_margin"
+            android:autoSizeMaxTextSize="@dimen/clock_text_size"
+            android:autoSizeMinTextSize="@dimen/extra_big_text_size"
+            android:autoSizeStepGranularity="2sp"
+            android:autoSizeTextType="uniform"
             android:fontFeatureSettings="tnum"
             android:gravity="center_horizontal"
+            android:maxLines="1"
             android:textSize="@dimen/clock_text_size"
             tools:text="00:00:00" />
 
@@ -39,7 +46,7 @@
             android:layout_below="@+id/clock_date"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="@dimen/medium_margin"
-            android:drawableLeft="@drawable/ic_clock_small"
+            android:drawableStart="@drawable/ic_clock_small"
             android:drawablePadding="@dimen/small_margin"
             android:gravity="center_horizontal"
             android:textSize="@dimen/big_text_size"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,8 +13,7 @@
     <dimen name="textview_drawable_size">24dp</dimen>
     <dimen name="drag_handle_size">40dp</dimen>
 
-    <dimen name="clock_text_size">70sp</dimen>
-    <dimen name="clock_text_size_smaller">60sp</dimen>
+    <dimen name="clock_text_size">80sp</dimen>
     <dimen name="alarm_text_size">60sp</dimen>
     <dimen name="timer_text_size">@dimen/alarm_text_size</dimen>
     <dimen name="stopwatch_text_size">80sp</dimen>


### PR DESCRIPTION
#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Enabled autofit on TextClock
- Made AM/PM in the clock fragment smaller as done in alarm fragment

#### Before/After Screenshots/Screen Record
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

<img alt="image" src="https://github.com/user-attachments/assets/0074ced1-5e5b-4128-9ca6-ca207d882b0d" width=179 />

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->

- Not tracked.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).