### PR TITLE
chore: ignore extra translations in lint

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -31,4 +31,5 @@
     <issue id="IconDensities" severity="warning" />
     <issue id="GradleDependency" severity="warning" />
     <issue id="Overdraw" severity="warning" />
+    <issue id="ExtraTranslation" severity="warning" />
 </lint>


### PR DESCRIPTION
#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Updated lint rules to ignore extra translations. They are removed automatically by Weblate.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).