### PR TITLE
Fix: Stopwatch lap times unseparated

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="stopwatch_button_small_size">60dp</dimen>
     <dimen name="stopwatch_button_size">64dp</dimen>
     <dimen name="reminder_background_min_size">70dp</dimen>
-    <dimen name="lap_time_size">80dp</dimen>
+    <dimen name="lap_time_size">120dp</dimen>
     <dimen name="widget_alarm_icon_size">18dp</dimen>
     <dimen name="widget_digital_time_height">48dp</dimen>
     <dimen name="widget_analogue_time_height">96dp</dimen>


### PR DESCRIPTION
Fix for spacing issue when lap time is longer than minutes when system font size is large e.g. 00:00.00

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Fixed stopwatch lap time display overlap/spacing issue
- Adjusted layout constraints to prevent lap time entries from overlapping with each other
- Improved visual spacing for better readability of lap times

#### Tests performed
- Tested on physical device (Samsung SM-S926B) via wireless ADB
- Verified lap time display with multiple lap entries
- Confirmed no overlap or spacing issues

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
Before: Lap times overlapped and were difficult to read
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/926c093f-3c56-4e75-bd2a-0523a4eec331" width=192 />
After: Lap times display with proper spacing and no overlap
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/1b106e43-f85c-4765-9dbf-837cb792dde4" width=192 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #346 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
