### PR TITLE
fix #406: Added the service for canceling the ringing sound

### DIFF
--- a/app/src/main/kotlin/org/fossify/clock/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/clock/extensions/Context.kt
@@ -59,6 +59,7 @@ import org.fossify.clock.receivers.HideTimerReceiver
 import org.fossify.clock.receivers.SkipUpcomingAlarmReceiver
 import org.fossify.clock.receivers.StopAlarmReceiver
 import org.fossify.clock.receivers.UpcomingAlarmReceiver
+import org.fossify.clock.services.AlarmService
 import org.fossify.clock.services.SnoozeService
 import org.fossify.commons.extensions.formatMinutesToTimeString
 import org.fossify.commons.extensions.formatSecondsToTimeString
@@ -280,6 +281,14 @@ fun Context.cancelAlarmClock(alarm: Alarm) {
     val alarmManager = alarmManager
     alarmManager.cancel(getAlarmIntent(alarm))
     alarmManager.cancel(getUpcomingAlarmPendingIntent(alarm))
+}
+
+fun Context.stopAlarmService(id: Int) {
+    val intent = Intent(this, AlarmService::class.java).apply {
+        action = AlarmService.ACTION_STOP_ALARM
+        putExtra(ALARM_ID, id)
+    }
+    startService(intent)
 }
 
 fun Context.hideNotification(id: Int) {

--- a/app/src/main/kotlin/org/fossify/clock/helpers/DBHelper.kt
+++ b/app/src/main/kotlin/org/fossify/clock/helpers/DBHelper.kt
@@ -9,6 +9,7 @@ import android.database.sqlite.SQLiteOpenHelper
 import android.text.TextUtils
 import org.fossify.clock.extensions.cancelAlarmClock
 import org.fossify.clock.extensions.createNewAlarm
+import org.fossify.clock.extensions.stopAlarmService
 import org.fossify.clock.models.Alarm
 import org.fossify.commons.extensions.getIntValue
 import org.fossify.commons.extensions.getStringValue
@@ -100,8 +101,8 @@ class DBHelper private constructor(
     fun deleteAlarms(alarms: ArrayList<Alarm>) {
         alarms.filter { it.isEnabled }.forEach {
             context.cancelAlarmClock(it)
+            context.stopAlarmService(it.id)
         }
-
         val args = TextUtils.join(", ", alarms.map { it.id.toString() })
         val selection = "$ALARMS_TABLE_NAME.$COL_ID IN ($args)"
         mDb.delete(ALARMS_TABLE_NAME, selection, null)

--- a/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
+++ b/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
@@ -60,14 +60,16 @@ class AlarmService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val action = intent?.action ?: ACTION_START_ALARM
         val alarmId = intent?.getIntExtra(ALARM_ID, -1) ?: -1
-        val newAlarm = applicationContext.dbHelper.getAlarmWithId(alarmId)
-        if (alarmId == -1 || newAlarm == null) {
-            stopSelfIfIdle()
-            return START_NOT_STICKY
-        }
 
         when (action) {
-            ACTION_START_ALARM -> startNewAlarm(newAlarm)
+            ACTION_START_ALARM -> {
+                val newAlarm = applicationContext.dbHelper.getAlarmWithId(alarmId)
+                if (alarmId == -1 || newAlarm == null) {
+                    stopSelfIfIdle()
+                    return START_NOT_STICKY
+                }
+                startNewAlarm(newAlarm)
+            }
             ACTION_STOP_ALARM -> stopActiveAlarm(alarmId)
             else -> throw IllegalArgumentException("Unknown action: $action")
         }


### PR DESCRIPTION
Added the service for canceling the ringing sound & adapted onStartCommand for the service that cancels the ringing sound.

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added part to stop ongoing service when clock is deleted.
- Adapted onStartCommand to handle cases where the alarm has been deleted, causing getAlarmWithId to return null.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested stopping alarms after they were deleted.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #406

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
