### PR TITLE
fix: show the alarm label in the upcoming-alarm notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added the alarm label to the upcoming alarm notification ([#183])
 
 ## [1.6.0] - 2026-01-30
 ### Added
@@ -106,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#107]: https://github.com/FossifyOrg/Clock/issues/107
 [#144]: https://github.com/FossifyOrg/Clock/issues/144
 [#158]: https://github.com/FossifyOrg/Clock/issues/158
+[#183]: https://github.com/FossifyOrg/Clock/issues/183
 [#206]: https://github.com/FossifyOrg/Clock/issues/206
 [#207]: https://github.com/FossifyOrg/Clock/issues/207
 [#247]: https://github.com/FossifyOrg/Clock/issues/247

--- a/app/src/main/kotlin/org/fossify/clock/receivers/UpcomingAlarmReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/clock/receivers/UpcomingAlarmReceiver.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import org.fossify.clock.R
+import org.fossify.clock.extensions.dbHelper
 import org.fossify.clock.extensions.getClosestEnabledAlarmString
 import org.fossify.clock.extensions.getOpenAlarmTabIntent
 import org.fossify.clock.extensions.getSkipUpcomingAlarmPendingIntent
@@ -35,6 +36,7 @@ class UpcomingAlarmReceiver : BroadcastReceiver() {
     }
 
     private fun showUpcomingAlarmNotification(context: Context, alarmId: Int) {
+        val label = context.dbHelper.getAlarmWithId(alarmId)?.label.orEmpty()
         context.getClosestEnabledAlarmString { alarmString ->
             val notificationManager = context.notificationManager
             NotificationChannel(
@@ -52,9 +54,15 @@ class UpcomingAlarmReceiver : BroadcastReceiver() {
                 alarmId = alarmId, notificationId = UPCOMING_ALARM_NOTIFICATION_ID
             )
 
+            val contentText = if (label.isNotEmpty()) {
+                "$alarmString - $label"
+            } else {
+                alarmString
+            }
+
             val notification = NotificationCompat.Builder(context, UPCOMING_ALARM_CHANNEL_ID)
                 .setContentTitle(context.getString(R.string.upcoming_alarm))
-                .setContentText(alarmString)
+                .setContentText(contentText)
                 .setSmallIcon(R.drawable.ic_alarm_vector)
                 .setPriority(Notification.PRIORITY_LOW)
                 .addAction(


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
The "Upcoming Alarm" notification (shown ~10 minutes before an alarm fires) only displayed the day and time, never the alarm's label. Its content text was set from `Context.getClosestEnabledAlarmString`, which by design produces only a `"$dayOfWeek $formattedTime"` string (e.g. "Mon 07:30"). That helper is intentionally shared with the in-app "next alarm" text (`ClockFragment`) and the digital home-screen widget (`MyDigitalTimeWidgetProvider`), both of which should keep showing only the time, so the label must not be appended there.

The fix is localized to `UpcomingAlarmReceiver`, which already receives the specific `ALARM_ID` through its PendingIntent. It now looks up that alarm by id (`context.dbHelper.getAlarmWithId(alarmId)?.label`) on the existing `goAsync` background (Dispatchers.IO) thread and appends the label to the notification content text as `"$alarmString - $label"` only when a label is present. When the alarm has no label, the notification text is unchanged. No shared code paths are affected.

#### Tests performed
Verified on a real Android 15 (API 35) emulator with the `foss` debug build installed. I created an enabled alarm scheduled a few minutes in the future and drove `UpcomingAlarmReceiver` for that alarm id, exactly as `AlarmManager` does ~10 minutes before an alarm fires. With the alarm labeled "Standup meeting", the posted "Upcoming alarm" notification's content text read `Sat 12:17 AM - Standup meeting` (confirmed both in `dumpsys notification` and visually in the notification shade). Repeating with the label cleared produced `Sat 12:17 AM` with no trailing `" - "` separator, and the shared `getClosestEnabledAlarmString` output (the `Sat 12:17 AM` portion) never contained the label — proving the change is localized to the receiver and the in-app "next alarm"/widget text is untouched. CI (detekt, lint, unit tests, build) also passes.

#### Closes the following issue(s)
- Closes #183

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
