### PR TITLE
fix: allow dismissing an alarm that was deleted while ringing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed alarms not stopping when dismissed or snoozed after being deleted while ringing ([#406])
 
 ## [1.6.0] - 2026-01-30
 ### Added
@@ -111,6 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#247]: https://github.com/FossifyOrg/Clock/issues/247
 [#335]: https://github.com/FossifyOrg/Clock/issues/335
 [#346]: https://github.com/FossifyOrg/Clock/issues/346
+[#406]: https://github.com/FossifyOrg/Clock/issues/406
 
 [Unreleased]: https://github.com/FossifyOrg/Clock/compare/1.6.0...HEAD
 [1.6.0]: https://github.com/FossifyOrg/Clock/compare/1.5.0...1.6.0

--- a/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
+++ b/app/src/main/kotlin/org/fossify/clock/services/AlarmService.kt
@@ -60,14 +60,25 @@ class AlarmService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val action = intent?.action ?: ACTION_START_ALARM
         val alarmId = intent?.getIntExtra(ALARM_ID, -1) ?: -1
-        val newAlarm = applicationContext.dbHelper.getAlarmWithId(alarmId)
-        if (alarmId == -1 || newAlarm == null) {
+        if (alarmId == -1) {
             stopSelfIfIdle()
             return START_NOT_STICKY
         }
 
         when (action) {
-            ACTION_START_ALARM -> startNewAlarm(newAlarm)
+            ACTION_START_ALARM -> {
+                // Starting requires the alarm to still exist in the DB.
+                val newAlarm = applicationContext.dbHelper.getAlarmWithId(alarmId)
+                if (newAlarm == null) {
+                    stopSelfIfIdle()
+                    return START_NOT_STICKY
+                }
+
+                startNewAlarm(newAlarm)
+            }
+
+            // Stopping only needs the id, so an alarm deleted while ringing
+            // can still be dismissed/snoozed. See issue #406.
             ACTION_STOP_ALARM -> stopActiveAlarm(alarmId)
             else -> throw IllegalArgumentException("Unknown action: $action")
         }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
`AlarmService.onStartCommand` looked up the alarm in the database up front and, whenever the record was missing, bailed out via `stopSelfIfIdle()` and returned `START_NOT_STICKY`. When an alarm is deleted while it is ringing (`AlarmsAdapter.deleteItems()` calls `dbHelper.deleteAlarms(...)` and posts `AlarmEvent.Refresh` but never stops the service), that lookup returns `null`. Every dismiss / snooze / silence path funnels through `AlarmController` -> `ACTION_STOP_ALARM` -> `onStartCommand`, so the null guard swallowed the stop request: `stopActiveAlarm(alarmId)` was never reached and `stopSelfIfIdle()` did nothing because `activeAlarm` was still set. The result was an alarm that keeps sounding with no way to dismiss or snooze it.

Only the START path actually needs the alarm object; the STOP path merely compares the id against the currently active alarm. This moves the DB lookup and its null guard into the `ACTION_START_ALARM` branch, leaving `ACTION_STOP_ALARM` able to stop a ringing alarm by id even after its DB row is gone. Behavior for the start path is unchanged.

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: `AlarmService` now null-guards `getAlarmWithId(alarmId)` inside the `ACTION_START_ALARM` branch so a still-ringing alarm that was deleted from the DB can be dismissed instead of leaving the service stuck. This is a defensive null check with a clear, contained effect.
- Note: staging a *ringing* alarm that is then deleted mid-ring is impractical on a stock emulator, so verification is via CI + code review.

#### Closes the following issue(s)
- Closes #406

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
